### PR TITLE
Removed XML tag in ComicInfo.xml

### DIFF
--- a/packer.go
+++ b/packer.go
@@ -171,7 +171,6 @@ func PackToCBZ(images []*bytes.Buffer, destination string, context *PackerContex
 
 func generateComicInfo(context *PackerContext) string {
 	return `
-<?xml version="1.0"?>
 <ComicInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Title>` + context.Chapter.Info + `</Title>
   <Series>` + context.Manga.Info + `</Series>


### PR DESCRIPTION
It seems the spec does not allow xml standalone <xml> tag at the beginning. which leads to errors in parsing in Komga

```log
Jul 01 16:01:33 server docker-compose[4396]: komga    | 2022-07-01 16:01:33.315  INFO 1 --- [ntContainer#1-1] o.g.k.d.service.BookMetadataLifecycle    : Refresh metadata for book: Book(name=[0001]_Vol.1_Chapter_0.01_The_Black_Swordsman, url=file:/data/Berserk/%5B0001%5D_Vol.1_Chapter_0.01_The_Black_Swordsman.cbz, fileLastModified=2022-06-30T23:34:33.127, fileSize=24503614, fileHash=1gpzq5q, number=1, id=095PWJMAB0PJ0, seriesId=095PWJMAB0PHZ, libraryId=0945REWR6FF22, deletedDate=null, createdDate=2022-07-01T16:00:30, lastModifiedDate=2022-07-01T16:00:34.406) with capabilities: [TITLE, SUMMARY, NUMBER, NUMBER_SORT, RELEASE_DATE, AUTHORS, TAGS, ISBN, READ_LISTS, THUMBNAILS, LINKS]
Jul 01 16:01:34 server docker-compose[4396]: komga    | 2022-07-01 16:01:34.545 ERROR 1 --- [ntContainer#1-1] o.g.k.i.m.comicrack.ComicInfoProvider    : Error while retrieving metadata from ComicInfo.xml
Jul 01 16:01:34 server docker-compose[4396]: komga    |
Jul 01 16:01:34 server docker-compose[4396]: komga    | com.fasterxml.jackson.core.JsonParseException: Illegal processing instruction target ("xml"); xml (case insensitive) is reserved by the specs.
Jul 01 16:01:34 server docker-compose[4396]: komga    |  at [row,col {unknown-source}]: [2,5]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at com.fasterxml.jackson.dataformat.xml.XmlFactory._initializeXmlReader(XmlFactory.java:713) ~[jackson-dataformat-xml-2.12.6.jar:2.12.6]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at com.fasterxml.jackson.dataformat.xml.XmlFactory._createParser(XmlFactory.java:648) ~[jackson-dataformat-xml-2.12.6.jar:2.12.6]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at com.fasterxml.jackson.dataformat.xml.XmlFactory._createParser(XmlFactory.java:30) ~[jackson-dataformat-xml-2.12.6.jar:2.12.6]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at com.fasterxml.jackson.core.JsonFactory.createParser(JsonFactory.java:1124) ~[jackson-core-2.12.6.jar:2.12.6]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3609) ~[jackson-databind-2.12.6.1.jar:2.12.6.1]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.gotson.komga.infrastructure.metadata.comicrack.ComicInfoProvider.getComicInfo(ComicInfoProvider.kt:150) ~[classes/:na]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.gotson.komga.infrastructure.metadata.comicrack.ComicInfoProvider.getBookMetadataFromBook(ComicInfoProvider.kt:46) ~[classes/:na]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.gotson.komga.domain.service.BookMetadataLifecycle.refreshMetadata(BookMetadataLifecycle.kt:54) ~[classes/:na]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.gotson.komga.application.tasks.TaskHandler.handleTask(TaskHandler.kt:110) ~[classes/:na]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at jdk.internal.reflect.GeneratedMethodAccessor133.invoke(Unknown Source) ~[na:na]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[na:na]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[na:na]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.springframework.messaging.handler.invocation.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:169) ~[spring-messaging-5.3.18.jar:5.3.18]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.springframework.messaging.handler.invocation.InvocableHandlerMethod.invoke(InvocableHandlerMethod.java:119) ~[spring-messaging-5.3.18.jar:5.3.18]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.springframework.jms.listener.adapter.MessagingMessageListenerAdapter.invokeHandler(MessagingMessageListenerAdapter.java:114) ~[spring-jms-5.3.18.jar:5.3.18]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.springframework.jms.listener.adapter.MessagingMessageListenerAdapter.onMessage(MessagingMessageListenerAdapter.java:77) ~[spring-jms-5.3.18.jar:5.3.18]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.springframework.jms.listener.AbstractMessageListenerContainer.doInvokeListener(AbstractMessageListenerContainer.java:736) ~[spring-jms-5.3.18.jar:5.3.18]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.springframework.jms.listener.AbstractMessageListenerContainer.invokeListener(AbstractMessageListenerContainer.java:696) ~[spring-jms-5.3.18.jar:5.3.18]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.springframework.jms.listener.AbstractMessageListenerContainer.doExecuteListener(AbstractMessageListenerContainer.java:674) ~[spring-jms-5.3.18.jar:5.3.18]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.springframework.jms.listener.AbstractPollingMessageListenerContainer.doReceiveAndExecute(AbstractPollingMessageListenerContainer.java:331) ~[spring-jms-5.3.18.jar:5.3.18]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.springframework.jms.listener.AbstractPollingMessageListenerContainer.receiveAndExecute(AbstractPollingMessageListenerContainer.java:270) ~[spring-jms-5.3.18.jar:5.3.18]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.springframework.jms.listener.DefaultMessageListenerContainer$AsyncMessageListenerInvoker.invokeListener(DefaultMessageListenerContainer.java:1237) ~[spring-jms-5.3.18.jar:5.3.18]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.springframework.jms.listener.DefaultMessageListenerContainer$AsyncMessageListenerInvoker.executeOngoingLoop(DefaultMessageListenerContainer.java:1227) ~[spring-jms-5.3.18.jar:5.3.18]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at org.springframework.jms.listener.DefaultMessageListenerContainer$AsyncMessageListenerInvoker.run(DefaultMessageListenerContainer.java:1120) ~[spring-jms-5.3.18.jar:5.3.18]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at java.base/java.lang.Thread.run(Unknown Source) ~[na:na]
Jul 01 16:01:34 server docker-compose[4396]: komga    | Caused by: com.ctc.wstx.exc.WstxParsingException: Illegal processing instruction target ("xml"); xml (case insensitive) is reserved by the specs.
Jul 01 16:01:34 server docker-compose[4396]: komga    |  at [row,col {unknown-source}]: [2,5]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at com.ctc.wstx.sr.StreamScanner.constructWfcException(StreamScanner.java:634) ~[woodstox-core-6.2.4.jar:6.2.4]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at com.ctc.wstx.sr.StreamScanner.throwParseError(StreamScanner.java:504) ~[woodstox-core-6.2.4.jar:6.2.4]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at com.ctc.wstx.sr.BasicStreamReader.readPIPrimary(BasicStreamReader.java:4023) ~[woodstox-core-6.2.4.jar:6.2.4]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at com.ctc.wstx.sr.BasicStreamReader.nextFromProlog(BasicStreamReader.java:2156) ~[woodstox-core-6.2.4.jar:6.2.4]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at com.ctc.wstx.sr.BasicStreamReader.next(BasicStreamReader.java:1180) ~[woodstox-core-6.2.4.jar:6.2.4]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         at com.fasterxml.jackson.dataformat.xml.XmlFactory._initializeXmlReader(XmlFactory.java:708) ~[jackson-dataformat-xml-2.12.6.jar:2.12.6]
Jul 01 16:01:34 server docker-compose[4396]: komga    |         ... 24 common frames omitted
```

After removing the tag the parser started working correctly.