### PR TITLE
Add simple JSON interface to mangal inline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   goreleaser:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/cmd/inline.go
+++ b/cmd/inline.go
@@ -18,6 +18,8 @@ func init() {
 	inlineCmd.Flags().String("manga", "", "manga selector")
 	inlineCmd.Flags().String("chapters", "", "chapter selector")
 	inlineCmd.Flags().BoolP("download", "d", false, "download chapters")
+	inlineCmd.Flags().BoolP("json", "j", false, "JSON output")
+	inlineCmd.Flags().BoolP("all", "a", false, "Return all mangas (--json only)")
 
 	lo.Must0(inlineCmd.MarkFlagRequired("query"))
 	lo.Must0(inlineCmd.MarkFlagRequired("manga"))
@@ -43,6 +45,13 @@ Chapter selectors:
   @[substring]@ - select chapters by name substring`,
 
 	Example: "mangal inline --source Manganelo --query \"death note\" --manga first --chapters \"@Vol.1 @\" -d",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		all, _ := cmd.Flags().GetBool("all")
+
+		if all {
+			cmd.MarkFlagRequired("json")
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		sourceName := viper.GetString(constant.DownloaderDefaultSource)
 		if sourceName == "" {
@@ -65,6 +74,8 @@ Chapter selectors:
 		options := &inline.Options{
 			Source:        src,
 			Download:      lo.Must(cmd.Flags().GetBool("download")),
+			Json:          lo.Must(cmd.Flags().GetBool("json")),
+			All:           lo.Must(cmd.Flags().GetBool("all")),
 			Query:         lo.Must(cmd.Flags().GetString("query")),
 			MangaPicker:   mangaPicker,
 			ChapterFilter: chapterFilter,

--- a/cmd/inline.go
+++ b/cmd/inline.go
@@ -23,6 +23,7 @@ func init() {
 
 	lo.Must0(inlineCmd.MarkFlagRequired("query"))
 	lo.Must0(inlineCmd.MarkFlagRequired("chapters"))
+	inlineCmd.MarkFlagsMutuallyExclusive("download", "json")
 }
 
 var inlineCmd = &cobra.Command{

--- a/cmd/inline.go
+++ b/cmd/inline.go
@@ -20,6 +20,7 @@ func init() {
 	inlineCmd.Flags().String("chapters", "", "chapter selector")
 	inlineCmd.Flags().BoolP("download", "d", false, "download chapters")
 	inlineCmd.Flags().BoolP("json", "j", false, "JSON output")
+	inlineCmd.Flags().BoolP("populate-pages", "p", false, "Populate chapters pages")
 
 	lo.Must0(inlineCmd.MarkFlagRequired("query"))
 	lo.Must0(inlineCmd.MarkFlagRequired("chapters"))
@@ -51,6 +52,10 @@ Chapter selectors:
 		if !json {
 			lo.Must0(cmd.MarkFlagRequired("manga"))
 		}
+
+		if lo.Must(cmd.Flags().GetBool("populate-pages")) {
+			lo.Must0(cmd.MarkFlagRequired("json"))
+		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		sourceName := viper.GetString(constant.DownloaderDefaultSource)
@@ -81,6 +86,7 @@ Chapter selectors:
 			Download:       lo.Must(cmd.Flags().GetBool("download")),
 			Json:           lo.Must(cmd.Flags().GetBool("json")),
 			Query:          lo.Must(cmd.Flags().GetString("query")),
+			PopulatePages:  lo.Must(cmd.Flags().GetBool("populate-pages")),
 			MangaPicker:    mangaPicker,
 			ChaptersFilter: chapterFilter,
 		}

--- a/inline/inline.go
+++ b/inline/inline.go
@@ -23,7 +23,9 @@ func Run(options *Options) error {
 	if options.Json && options.All {
 		// pre-load _all_ chapters
 		for _, manga := range mangas {
-			jsonUpdateChapters(manga, options)
+			if err = jsonUpdateChapters(manga, options); err != nil {
+				return err
+			}
 		}
 
 		return jsonPrint(&JsonData{Manga: mangas})
@@ -46,7 +48,9 @@ func Run(options *Options) error {
 	}
 
 	if options.Json {
-		jsonUpdateChapters(manga, options)
+		if err = jsonUpdateChapters(manga, options); err != nil {
+			return err
+		}
 
 		mangas := make([]*source.Manga, 1)
 		mangas[0] = manga

--- a/inline/inline.go
+++ b/inline/inline.go
@@ -23,23 +23,10 @@ func Run(options *Options) error {
 	if options.Json && options.All {
 		// pre-load _all_ chapters
 		for _, manga := range mangas {
-			chapters, _ := options.Source.ChaptersOf(manga)
-			chapters, err := options.ChapterFilter(chapters)
-
-			if err == nil {
-				manga.Chapters = chapters
-			}
+			jsonUpdateChapters(manga, options)
 		}
 
-		marshalledMangas, err := json.Marshal(&JsonData{Manga: mangas})
-
-		if err != nil {
-			return err
-		}
-
-		fmt.Print(string(marshalledMangas))
-
-		return nil
+		return jsonPrint(&JsonData{Manga: mangas})
 	}
 
 	manga := options.MangaPicker(mangas)
@@ -59,17 +46,11 @@ func Run(options *Options) error {
 	}
 
 	if options.Json {
+		jsonUpdateChapters(manga, options)
+
 		mangas := make([]*source.Manga, 1)
 		mangas[0] = manga
-		marshalledManga, err := json.Marshal(&JsonData{Manga: mangas})
-
-		if err != nil {
-			return err
-		}
-
-		fmt.Print(string(marshalledManga))
-
-		return nil
+		return jsonPrint(&JsonData{Manga: mangas})
 	}
 
 	for _, chapter := range chapters {
@@ -87,6 +68,29 @@ func Run(options *Options) error {
 			}
 		}
 	}
+
+	return nil
+}
+
+func jsonUpdateChapters(manga *source.Manga, options *Options) error {
+	chapters, _ := options.Source.ChaptersOf(manga)
+	chapters, err := options.ChapterFilter(chapters)
+
+	if err == nil {
+		manga.Chapters = chapters
+	}
+
+	return err
+}
+
+func jsonPrint(data *JsonData) error {
+	marshalledManga, err := json.Marshal(data)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(string(marshalledManga))
 
 	return nil
 }

--- a/inline/json.go
+++ b/inline/json.go
@@ -1,9 +1,34 @@
 package inline
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/metafates/mangal/source"
+	"os"
 )
 
-type JsonData struct {
-	Manga []*source.Manga
+func printAsJson(manga []*source.Manga) error {
+	marshalled, err := json.Marshal(&struct {
+		Manga []*source.Manga
+	}{
+		Manga: manga,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprint(os.Stdout, string(marshalled))
+	return err
+}
+
+func jsonUpdateChapters(manga *source.Manga, options *Options) error {
+	chapters, _ := options.Source.ChaptersOf(manga)
+	chapters, err := options.ChaptersFilter(chapters)
+
+	if err == nil {
+		manga.Chapters = chapters
+	}
+
+	return err
 }

--- a/inline/json.go
+++ b/inline/json.go
@@ -26,9 +26,20 @@ func jsonUpdateChapters(manga *source.Manga, options *Options) error {
 	chapters, _ := options.Source.ChaptersOf(manga)
 	chapters, err := options.ChaptersFilter(chapters)
 
-	if err == nil {
-		manga.Chapters = chapters
+	if err != nil {
+		return err
 	}
 
-	return err
+	manga.Chapters = chapters
+
+	if options.PopulatePages {
+		for _, chapter := range chapters {
+			_, err := options.Source.PagesOf(chapter)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/inline/json.go
+++ b/inline/json.go
@@ -1,0 +1,9 @@
+package inline
+
+import (
+	"github.com/metafates/mangal/source"
+)
+
+type JsonData struct {
+	Manga []*source.Manga
+}

--- a/inline/options.go
+++ b/inline/options.go
@@ -21,6 +21,7 @@ type Options struct {
 	Source         source.Source
 	Download       bool
 	Json           bool
+	PopulatePages  bool
 	Query          string
 	MangaPicker    util.Option[MangaPicker]
 	ChaptersFilter ChaptersFilter
@@ -111,7 +112,7 @@ func ParseChaptersFilter(description string) (ChaptersFilter, error) {
 				from, to = to, from
 			}
 
-			return chapters[from:to], nil
+			return chapters[from : to+1], nil
 		}
 	}, nil
 }

--- a/source/chapter.go
+++ b/source/chapter.go
@@ -22,7 +22,7 @@ type Chapter struct {
 	// ID of the chapter in the source.
 	ID string
 	// Manga that the chapter belongs to.
-	Manga *Manga
+	Manga *Manga `json:"-"`
 	// Pages of the chapter.
 	Pages []*Page
 }

--- a/source/manga.go
+++ b/source/manga.go
@@ -22,7 +22,7 @@ type Manga struct {
 	ID string
 	// Chapters of the manga
 	Chapters       []*Chapter
-	Source         Source
+	Source         Source `json:"-"`
 	cachedTempPath string
 }
 

--- a/source/page.go
+++ b/source/page.go
@@ -18,11 +18,11 @@ type Page struct {
 	// Extension of the page image.
 	Extension string
 	// Size of the page in bytes
-	Size uint64
+	Size uint64 `json:"-"`
 	// Contents of the page
-	Contents io.ReadCloser
+	Contents io.ReadCloser `json:"-"`
 	// Chapter that the page belongs to.
-	Chapter *Chapter
+	Chapter *Chapter `json:"-"`
 }
 
 // Download Page contents.

--- a/util/option.go
+++ b/util/option.go
@@ -1,0 +1,26 @@
+package util
+
+type Option[T any] struct {
+	value  T
+	isSome bool
+}
+
+func (o Option[T]) Unwrap() T {
+	return o.value
+}
+
+func (o Option[T]) IsSome() bool {
+	return o.isSome
+}
+
+func (o Option[T]) IsNone() bool {
+	return !o.isSome
+}
+
+func Some[T any](value T) Option[T] {
+	return Option[T]{value: value, isSome: true}
+}
+
+func None[T any]() Option[T] {
+	return Option[T]{isSome: false}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -124,3 +124,14 @@ func Max[T constraints.Ordered](items ...T) (max T) {
 
 	return
 }
+
+func Min[T constraints.Ordered](items ...T) (min T) {
+	min = items[0]
+	for _, item := range items {
+		if item < min {
+			min = item
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
I've added a simple JSON interface to the `inline` command, so I can (eventually) build a proof-of-concept web interface to go together with Komga etc.

This is the first step towards a Node.JS/Typescript package that interfaces with mangal.

It just returns the internal data structure (without cyclic dependencies) onto the terminal as JSON. This allows other applications to interface with mangal, and download specific chapters using the `inline` command.

In this PR, I implemented the following:
- `--json`: Returns JSON output of query result instead of default download or view action.
- `--all`: (Only in combination with `--json`) returns all results that match (Note that the chapter selection works here, too)

Code may not be of highest quality, as this is my first time actually programming in Go :upside_down_face: 