### PR TITLE
Add environment variable to disable version check entirely

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -409,6 +409,11 @@ panic, fatal, error, warn, info, debug, trace`,
 		true,
 		"Use colors in CLI help page",
 	},
+	{
+		key.CliVersionCheck,
+		true,
+		"Check for a new version of the CLI occasionally",
+	},
 }
 
 func init() {

--- a/key/keys.go
+++ b/key/keys.go
@@ -3,7 +3,7 @@ package key
 // DefinedFieldsCount is the number of fields defined in this package.
 // You have to manually update this number when you add a new field
 // to check later if every field has a defined default value
-const DefinedFieldsCount = 52
+const DefinedFieldsCount = 53
 
 const (
 	DownloaderPath                = "downloader.path"
@@ -99,5 +99,6 @@ const (
 )
 
 const (
-	CliColored = "cli.colored"
+	CliColored      = "cli.colored"
+	CliVersionCheck = "cli.version_check"
 )

--- a/version/notify.go
+++ b/version/notify.go
@@ -5,11 +5,17 @@ import (
 	"github.com/metafates/mangal/color"
 	"github.com/metafates/mangal/constant"
 	"github.com/metafates/mangal/icon"
+	"github.com/metafates/mangal/key"
 	"github.com/metafates/mangal/style"
 	"github.com/metafates/mangal/util"
+	"github.com/spf13/viper"
 )
 
 func Notify() {
+	if !viper.GetBool(key.CliVersionCheck) {
+		return
+	}
+
 	erase := util.PrintErasable(fmt.Sprintf("%s Checking if new version is available...", icon.Get(icon.Progress)))
 	version, err := Latest()
 	erase()


### PR DESCRIPTION
As someone who has Github notification enabled, I find version checking quite useless, and there is also Github's API rate limit to be concerned. I know it only triggers with `--help` and `--version` flags, and also caches the result, but I'm an airhead that hits the help command every 1-2 minutes.

This simple commit introduces `MANGAL_DISABLE_VERSION_CHECK` environment variable, which a user can set to any non-empty values to have a peace of mind.