### PR TITLE
fix naming and order in mangadex

### DIFF
--- a/provider/mangadex/chapters.go
+++ b/provider/mangadex/chapters.go
@@ -62,17 +62,11 @@ func (m *Mangadex) ChaptersOf(manga *source.Manga) ([]*source.Chapter, error) {
 				continue
 			}
 
-			num, err := strconv.ParseUint(chapter.GetChapterNum(), 10, 16)
-			n := uint16(num)
-			if err != nil {
-				n = uint16(i)
-			}
-
 			name := chapter.GetTitle()
 			if name == "" {
-				name = fmt.Sprintf("Chapter %d", n)
+				name = fmt.Sprintf("Chapter %s", chapter.GetChapterNum())
 			} else {
-				name = fmt.Sprintf("Chapter %d - %s", n, name)
+				name = fmt.Sprintf("Chapter %s - %s", chapter.GetChapterNum(), name)
 			}
 
 			var volume string
@@ -81,7 +75,7 @@ func (m *Mangadex) ChaptersOf(manga *source.Manga) ([]*source.Chapter, error) {
 			}
 			chapters = append(chapters, &source.Chapter{
 				Name:   name,
-				Index:  n,
+				Index:  uint16(i),
 				ID:     chapter.ID,
 				URL:    fmt.Sprintf("https://mangadex.org/chapter/%s", chapter.ID),
 				Manga:  manga,


### PR DESCRIPTION
Fixes a very small bit of very strange behavior in the built in mangadex provider - it would scrape everything just fine as far as i could tell but any "in between" chapters with decimal chapter numbers would be pushed to the end with very large and incorrect chapter numbers courtesy of the `uint16()` function. This PR just makes it so the chapter index is always simply incremented to achieve the correct ordering and the chapter title now gets its number directly from the `mangodex.Chapter.GetChapterNum()` function, no conversions needed since its just put in a string anyways.

Note that caching is a problem here, I wasn't sure if this was even something that should be solved in the code, as opposed to an install script or package so I just left it alone for now. For testing I just commented out the portion that returns that cache.

**Before**:

![Screenshot on February 14, 2023 - 5:09:15 PM](https://user-images.githubusercontent.com/91640048/218900073-ebcf6a2a-e299-4314-805d-b9fa93f1130b.png)


**After**:

![Screenshot on February 14, 2023 - 5:09:21 PM](https://user-images.githubusercontent.com/91640048/218900153-007ba79a-ecf2-42b4-b411-626448e112dd.png)

![Screenshot on February 14, 2023 - 5:09:29 PM](https://user-images.githubusercontent.com/91640048/218900163-df0df52e-a7b3-405e-a9a7-669517c5588d.png)
