### PR TITLE
Make goreleaser put bins in /usr/bin

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -166,7 +166,7 @@ nfpms:
       - deb
       - rpm
 
-    bindir: /usr/local/bin
+    bindir: /usr/bin
     section: utils
 
     deb:


### PR DESCRIPTION
External packages should not put things into /usr/local.
