### PR TITLE
change manganato+mangapill search

### DIFF
--- a/provider/manganato/manganato.go
+++ b/provider/manganato/manganato.go
@@ -20,7 +20,7 @@ var Config = &generic.Configuration{
 		query = strings.TrimSpace(query)
 		query = strings.ToLower(query)
 		query = url.QueryEscape(query)
-		template := "https://chapmanganato.com/https://manganato.com/search/story/%s"
+		template := "https://manganato.com/search/story/%s"
 		return fmt.Sprintf(template, query)
 	},
 	MangaExtractor: &generic.Extractor{

--- a/provider/manganato/manganato.go
+++ b/provider/manganato/manganato.go
@@ -2,11 +2,12 @@ package manganato
 
 import (
 	"fmt"
-	"github.com/PuerkitoBio/goquery"
-	"github.com/metafates/mangal/provider/generic"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/metafates/mangal/provider/generic"
 )
 
 var Config = &generic.Configuration{
@@ -20,7 +21,7 @@ var Config = &generic.Configuration{
 		query = strings.TrimSpace(query)
 		query = strings.ToLower(query)
 		query = url.QueryEscape(query)
-		template := "https://manganato.com/search/story/%s"
+		template := "https://chapmanganato.to/https://manganato.com/search/story/%s"
 		return fmt.Sprintf(template, query)
 	},
 	MangaExtractor: &generic.Extractor{

--- a/provider/manganato/manganato.go
+++ b/provider/manganato/manganato.go
@@ -2,12 +2,11 @@ package manganato
 
 import (
 	"fmt"
+	"github.com/PuerkitoBio/goquery"
+	"github.com/metafates/mangal/provider/generic"
 	"net/url"
 	"strings"
 	"time"
-
-	"github.com/PuerkitoBio/goquery"
-	"github.com/metafates/mangal/provider/generic"
 )
 
 var Config = &generic.Configuration{

--- a/provider/mangapill/mangapill.go
+++ b/provider/mangapill/mangapill.go
@@ -2,12 +2,11 @@ package mangapill
 
 import (
 	"fmt"
+	"github.com/PuerkitoBio/goquery"
+	"github.com/metafates/mangal/provider/generic"
 	"net/url"
 	"strings"
 	"time"
-
-	"github.com/PuerkitoBio/goquery"
-	"github.com/metafates/mangal/provider/generic"
 )
 
 var Config = &generic.Configuration{

--- a/provider/mangapill/mangapill.go
+++ b/provider/mangapill/mangapill.go
@@ -2,11 +2,12 @@ package mangapill
 
 import (
 	"fmt"
-	"github.com/PuerkitoBio/goquery"
-	"github.com/metafates/mangal/provider/generic"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/metafates/mangal/provider/generic"
 )
 
 var Config = &generic.Configuration{
@@ -16,7 +17,6 @@ var Config = &generic.Configuration{
 	ReverseChapters: true,
 	BaseURL:         "https://mangapill.com",
 	GenerateSearchURL: func(query string) string {
-		query = strings.ReplaceAll(query, " ", "+")
 		query = strings.ToLower(query)
 		query = strings.TrimSpace(query)
 		template := "https://mangapill.com/search?q=%s&type=&status="


### PR DESCRIPTION
Search stopped returning hits for me for mangal a few days ago.
Today I cloned the project and started debugging as to why this was, and found that the old search url only returns 404 now.
Updating the search url to the one used when manually searching seems to have done the trick for me.

Not sure if there are any other ways I can test out that this is not breaking anything, please let me know!