### PR TITLE
Fixing the CreateVolumeDir option

### DIFF
--- a/source/chapter.go
+++ b/source/chapter.go
@@ -147,7 +147,7 @@ func (c *Chapter) IsDownloaded() bool {
 }
 
 func (c *Chapter) path(relativeTo string) (path string, err error) {
-    if c.Volume != "" && viper.GetBool(key.DownloaderCreateVolumeDir) {
+	if c.Volume != "" && viper.GetBool(key.DownloaderCreateVolumeDir) {
 		path = filepath.Join(relativeTo, util.SanitizeFilename(c.Volume))
 		err = filesystem.Api().MkdirAll(path, os.ModePerm)
 		if err != nil {

--- a/source/chapter.go
+++ b/source/chapter.go
@@ -140,14 +140,14 @@ func (c *Chapter) IsDownloaded() bool {
 		return c.isDownloaded.MustGet()
 	}
 
-	path, _ := c.path(c.Manga.peekPath(), false)
+	path, _ := c.path(c.Manga.peekPath())
 	exists, _ := filesystem.Api().Exists(path)
 	c.isDownloaded = mo.Some(exists)
 	return exists
 }
 
-func (c *Chapter) path(relativeTo string, createVolumeDir bool) (path string, err error) {
-	if createVolumeDir {
+func (c *Chapter) path(relativeTo string) (path string, err error) {
+    if c.Volume != "" && viper.GetBool(key.DownloaderCreateVolumeDir) {
 		path = filepath.Join(relativeTo, util.SanitizeFilename(c.Volume))
 		err = filesystem.Api().MkdirAll(path, os.ModePerm)
 		if err != nil {
@@ -155,7 +155,7 @@ func (c *Chapter) path(relativeTo string, createVolumeDir bool) (path string, er
 		}
 		path = filepath.Join(path, c.Filename())
 		return
-	}
+    }
 
 	path = filepath.Join(relativeTo, c.Filename())
 	return
@@ -168,7 +168,7 @@ func (c *Chapter) Path(temp bool) (path string, err error) {
 		return
 	}
 
-	return c.path(manga, c.Volume != "" && viper.GetBool(key.DownloaderCreateVolumeDir))
+	return c.path(manga)
 }
 
 func (c *Chapter) Source() Source {

--- a/source/chapter.go
+++ b/source/chapter.go
@@ -148,11 +148,13 @@ func (c *Chapter) IsDownloaded() bool {
 
 func (c *Chapter) path(relativeTo string, createVolumeDir bool) (path string, err error) {
 	if createVolumeDir {
-		path = filepath.Join(path, util.SanitizeFilename(c.Volume))
+		path = filepath.Join(relativeTo, util.SanitizeFilename(c.Volume))
 		err = filesystem.Api().MkdirAll(path, os.ModePerm)
 		if err != nil {
 			return
 		}
+		path = filepath.Join(path, c.Filename())
+		return
 	}
 
 	path = filepath.Join(relativeTo, c.Filename())


### PR DESCRIPTION
When setting `create_volume_dir = true` on config, it wasn't actually creating the directories for the volumes, so i did these little fixes. Also, it will check if the chapter has been downloaded when using the volume_dir option.