### PR TITLE
Change Mangadex provider sorting to show more relevant results

### DIFF
--- a/provider/mangadex/search.go
+++ b/provider/mangadex/search.go
@@ -34,7 +34,7 @@ func (m *Mangadex) Search(query string) ([]*source.Manga, error) {
 		params.Add("contentRating[]", mangodex.Erotica)
 	}
 
-	params.Set("order[followedCount]", "desc")
+	params.Set("order[relevance]", "desc")
 	params.Set("title", query)
 
 	mangaList, err := m.client.Manga.GetMangaList(params)


### PR DESCRIPTION
Hi,

So I was doing some searching with the inline feature and noted that some random Mangadex entries just refuse to match with `--manga exact`.

After a bit of research, I noted that this happens when certain conditions are met:
- count of results from Mangadex's search API is higher than the limit in the code [(100)](https://github.com/metafates/mangal/blob/main/provider/mangadex/search.go#L24).
- Is sorted unfavorably in Mangadex.

Example that I found after a bit of trial and error:
`mangal -S Mangadex inline --query 'HA-HA' --manga 'exact' -j` returns a lot of results (755 at the moment of writing this)
This example case gets sorted after the limit, and thus will never be found by mangal. Workaround for this is to search altTitles, but _in my very personal opinion_, I think it would be more user friendly to use Mangadex's sorting algorithm to show us relevant results rather than sort by some other statistic.


Feel free to reject the PR if you feel this is not something we don't want to change.

Thanks!