### PR TITLE
Fix ram usage for bulk downloads (inline mode)

### DIFF
--- a/inline/inline.go
+++ b/inline/inline.go
@@ -131,6 +131,10 @@ func Run(options *Options) (err error) {
 			if err != nil {
 				log.Warn(err)
 			}
+			// free memory after downloading
+			for _, page := range chapter.Pages {
+				page.Contents = nil
+			}
 		} else {
 			err := downloader.Read(chapter, func(string) {})
 			if err != nil {


### PR DESCRIPTION
When downloading a bunch of chapters from a manga in inline mode, the RAM usage continued to grow because the contents of a Page were never deleted.
This PR just deletes the contents of pages that were already saved to disk.